### PR TITLE
fixed array lookup in iterator which was undefined

### DIFF
--- a/lsjs.js
+++ b/lsjs.js
@@ -290,6 +290,7 @@ var define;
 		var m = modules[id];
 		m.args = [];
 		m.deploaded = {};
+		m.dependencies = [];
 		var idx = 0;
 		var iterate = function(itr) {
 			if (itr.hasMore()) {


### PR DESCRIPTION
Without the fix i got an error in the following line https://github.com/zazl/lsjs/blob/master/lsjs.js#L25

`this.array` was undefined and threw an error 

``` js
//index.html

  lsjs({
    baseUrl: "./"
  });

  lsjs(["./test"]);

```

``` js
// test.js

lsjs(['./test1'], function(test1){
    test1.alert();
});

```
