### PR TITLE
fix rendering of Markdown heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#lsjs
+# lsjs
 
 An AMD compliant loader that loads modules from localStorage. 
 


### PR DESCRIPTION
Just went down the history of AMD and found this library... I may be 12 years too late but I think that **lsjs** deserves a proper H1 heading. 😅